### PR TITLE
Updated plugin config for some persistence examples

### DIFF
--- a/persistence/address-book/pom.xml
+++ b/persistence/address-book/pom.xml
@@ -48,9 +48,11 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
+                            <options>
+                                <eclipselink.persistencexml>${basedir}/src/main/resources/META-INF/persistence.xml</eclipselink.persistencexml>
+                            </options>
                             <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
                             <outputDirectory>${project.build.directory}/generated-sources/metamodel</outputDirectory>
-                            <compilerArguments>-Aeclipselink.persistencexml=${basedir}/src/main/resources/META-INF/persistence.xml</compilerArguments>
                             <processors>
                                 <processor>org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProcessor</processor>
                             </processors>

--- a/persistence/roster/roster-ejb/pom.xml
+++ b/persistence/roster/roster-ejb/pom.xml
@@ -60,9 +60,11 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
+                            <options>
+                                <eclipselink.persistencexml>${basedir}/src/main/resources/META-INF/persistence.xml</eclipselink.persistencexml>
+                            </options>
                             <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
                             <outputDirectory>${project.build.directory}/generated-sources/metamodel</outputDirectory>
-                            <compilerArguments>-Aeclipselink.persistencexml=${basedir}/src/main/resources/META-INF/persistence.xml</compilerArguments>
                             <processors>
                                 <processor>org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProcessor</processor>
                             </processors>


### PR DESCRIPTION
Although #7 has been closed, I thought it might be nice if the relevant config was updated in a way that should just work when paths contain spaces (given that that is possible).  Accordingly, I have modified the way the path to the persistence.xml file was being specified in the maven-processor-plugin configuration as recommended by the developer of the plugin here: https://github.com/bsorrentino/maven-annotation-plugin/issues/62.

Note: I haven't signed the Oracle Contributor Agreement yet (I'll need to track down a printer to do that).  I just wanted to get this up and ready to go.  I'll update this once I've completed the agreement (or feel free to decline this if that's easier to track).