### PR TITLE
[connectors/trading] Fixed for deploy on Weblogic 12.2.1.2.

### DIFF
--- a/connectors/trading/trading-ear/pom.xml
+++ b/connectors/trading/trading-ear/pom.xml
@@ -35,6 +35,17 @@
                     </modules>
                 </configuration>
             </plugin>
+            
+            <!-- Uncomment the following plugin to build for Weblogic -->
+            
+            <!--<plugin>
+                <groupId>org.codehaus.cargo</groupId>
+                <artifactId>cargo-maven2-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>-->
+            
         </plugins>
     </build>
   

--- a/connectors/trading/trading-rar/src/main/java/javaeetutorial/trading/rar/api/TradeConnectionFactory.java
+++ b/connectors/trading/trading-rar/src/main/java/javaeetutorial/trading/rar/api/TradeConnectionFactory.java
@@ -7,9 +7,11 @@
  */
 package javaeetutorial.trading.rar.api;
 
+import java.io.Serializable;
+import javax.resource.Referenceable;
 import javax.resource.ResourceException;
 
-public interface TradeConnectionFactory {
+public interface TradeConnectionFactory extends Serializable, Referenceable {
 
     /* Applications call this method, which delegates on the container's
      * connection manager to obtain a connection instance through

--- a/connectors/trading/trading-rar/src/main/java/javaeetutorial/trading/rar/outbound/TradeConnectionFactoryImpl.java
+++ b/connectors/trading/trading-rar/src/main/java/javaeetutorial/trading/rar/outbound/TradeConnectionFactoryImpl.java
@@ -10,6 +10,8 @@ package javaeetutorial.trading.rar.outbound;
 import java.util.logging.Logger;
 import javaeetutorial.trading.rar.api.TradeConnection;
 import javaeetutorial.trading.rar.api.TradeConnectionFactory;
+import javax.naming.NamingException;
+import javax.naming.Reference;
 import javax.resource.ResourceException;
 import javax.resource.spi.ConnectionManager;
 
@@ -19,7 +21,8 @@ public class TradeConnectionFactoryImpl implements TradeConnectionFactory {
 
     private static final Logger log = Logger.getLogger("TradeConnectionFactoryImpl");
     private ConnectionManager cmanager;
-    private TradeManagedConnectionFactory mcfactory;
+    private TradeManagedConnectionFactory mcfactory;    
+    private Reference reference;
     
     /* The container creates instances of this class 
      * through TradeManagedConnectionFactory.createConnectionFactory() */
@@ -37,4 +40,15 @@ public class TradeConnectionFactoryImpl implements TradeConnectionFactory {
         log.info("[TradeConnectionFactoryImpl] getConnection()");
         return (TradeConnection) cmanager.allocateConnection(mcfactory, null);
     }
+
+    @Override
+    public void setReference(Reference reference) {
+        this.reference = reference;
+    }
+
+    @Override
+    public Reference getReference() throws NamingException {
+        return this.reference;
+    }
+    
 }

--- a/connectors/trading/trading-rar/src/main/java/javaeetutorial/trading/rar/outbound/TradeManagedConnectionFactory.java
+++ b/connectors/trading/trading-rar/src/main/java/javaeetutorial/trading/rar/outbound/TradeManagedConnectionFactory.java
@@ -10,15 +10,16 @@ package javaeetutorial.trading.rar.outbound;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
+import javaeetutorial.trading.rar.api.TradeConnection;
+import javaeetutorial.trading.rar.api.TradeConnectionFactory;
 
 import javax.naming.NamingException;
 import javax.naming.Reference;
 import javax.resource.Referenceable;
 import javax.resource.ResourceException;
-import javax.resource.cci.Connection;
-import javax.resource.cci.ConnectionFactory;
 import javax.resource.spi.ConfigProperty;
 import javax.resource.spi.ConnectionDefinition;
 import javax.resource.spi.ConnectionManager;
@@ -35,9 +36,9 @@ import javax.security.auth.Subject;
 
 /* Define classes an interfaces for the EIS physical connection */
 @ConnectionDefinition(
-    connectionFactory = ConnectionFactory.class,
+    connectionFactory = TradeConnectionFactory.class,
     connectionFactoryImpl = TradeConnectionFactoryImpl.class,
-    connection = Connection.class,
+    connection = TradeConnection.class,
     connectionImpl = TradeConnectionImpl.class
 )
 public class TradeManagedConnectionFactory implements ManagedConnectionFactory,
@@ -142,5 +143,39 @@ public class TradeManagedConnectionFactory implements ManagedConnectionFactory,
     public Reference getReference() throws NamingException {
         return reference;
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 53 * hash + Objects.hashCode(this.ra);
+        hash = 53 * hash + Objects.hashCode(this.reference);
+        hash = 53 * hash + Objects.hashCode(this.logWriter);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final TradeManagedConnectionFactory other = (TradeManagedConnectionFactory) obj;
+        if (!Objects.equals(this.ra, other.ra)) {
+            return false;
+        }
+        if (!Objects.equals(this.reference, other.reference)) {
+            return false;
+        }
+        if (!Objects.equals(this.logWriter, other.logWriter)) {
+            return false;
+        }
+        return true;
+    }
+    
     
 }


### PR DESCRIPTION
This fix make **connectors/training** example deployable on Weblogic (12.2.1.2) too.

The original source code throws the following exception at deployment time:

> An error occurred during activation of changes, please see the log for details.
> 
> [1] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionFactoryImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionFactoryImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement java.io.Serializable but does not. [2] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionFactoryImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionFactoryImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement javax.resource.Referenceable but does not. [3] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionFactoryImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionFactoryImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement javax.resource.cci.ConnectionFactory but does not. [4] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement javax.resource.cci.Connection but does not. [5] The class 'javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory', which is defined as [@javax.resource.spi.ConnectionDefinition] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must override both equals() and hashCode(), but does not.
> 
> Substituted for missing class [1] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionFactoryImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionFactoryImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement java.io.Serializable but does not. - [2] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionFactoryImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionFactoryImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement javax.resource.Referenceable but does not. [3] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionFactoryImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionFactoryImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement javax.resource.cci.ConnectionFactory but does not. [4] The class 'javaeetutorial.trading.rar.outbound.TradeConnectionImpl', which is defined as [@javax.resource.spi.ConnectionDefinition.connectionImpl] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must implement javax.resource.cci.Connection but does not. [5] The class 'javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory', which is defined as [@javax.resource.spi.ConnectionDefinition] from [Class javaeetutorial.trading.rar.outbound.TradeManagedConnectionFactory], must override both equals() and hashCode(), but does not.